### PR TITLE
Treat descriptor.characteristic as optional on Xcode13

### DIFF
--- a/Sources/ESPProvision/Utility/ESPUtility.swift
+++ b/Sources/ESPProvision/Utility/ESPUtility.swift
@@ -47,12 +47,22 @@ class ESPUtility {
     ///
     /// - Parameter descriptor: The CBDescriptor of a BLE characteristic.
     func processDescriptor(descriptor: CBDescriptor) {
+        
+    #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000
         if let value = descriptor.value as? String, let char = descriptor.characteristic {
+    #else
+        if let value = descriptor.value as? String {
+    #endif
+    
             if value.contains(ESPConstants.sessionPath) {
                 peripheralConfigured = true
                 sessionCharacteristic = descriptor.characteristic
-            }
+            }        
+    #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000        
             configUUIDMap.updateValue(char, forKey: value)
+    #else
+            configUUIDMap.updateValue(descriptor.characteristic, forKey: value)
+    #endif
         }
     }
 }


### PR DESCRIPTION
This change causes Xcode12 to treat a property as non-optional, while Xcode13 treats as optional